### PR TITLE
Don't use `find_packages`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     long_description=readsybling('README.md'),
     url="https://github.com/DIKU-EDU/Staffeli",
     version='0.3.6',
-    packages=find_packages(),
+    packages=["staffeli"],
     maintainer="Oleks",
     maintainer_email="oleks@oleks.info",
     license="EUPLv1.1",


### PR DESCRIPTION
`find_packages` has problems with packages without an `__init__.py` file (this is the short version, see <https://github.com/pypa/setuptools/issues/97> for more information).