### PR TITLE
Add command for splitting submissions by student sections

### DIFF
--- a/staffeli/canvas.py
+++ b/staffeli/canvas.py
@@ -197,6 +197,41 @@ class GroupCategoryList(cachable.CachableEntity):
         json = copy.deepcopy(self.json)
         return { 'group_categories': json }
 
+class SectionList:
+    def __init__(self, course, id=None):
+        self.canvas = course.canvas
+
+        entities = {}
+        if id is not None:
+            self.id = id
+        else:
+            entities = self.canvas.list_sections(course.id)
+            self.json = entities
+
+        sectmap = {}
+        sections = []
+        for ent in entities:
+            name = ent['name']
+            sections.append(name)
+            students = ent['students']
+            for student in students:
+                key = int(student['id'])
+                if key in sectmap:
+                    sectmap[key].append(name)
+                else:
+                    sectmap[int(student['id'])] = [name]
+        self._sectmap = sectmap
+        self._sections = sections
+
+    def sections(self):
+        """Return a list sections in course."""
+        return self._sections
+
+    def sectmap(self):
+        """Return a map between userIDs and section names."""
+        return self._sectmap
+
+
 class Course(listed.ListedEntity, cachable.CachableEntity):
     def __init__(self, canvas = None, name = None, id = None):
 

--- a/staffeli/cli.py
+++ b/staffeli/cli.py
@@ -237,6 +237,46 @@ def split_according_to_groups(course, subspath, path):
                 tgt = os.path.join(namepath, dirname)
                 shutil.copytree(src, tgt, symlinks=True)
 
+
+def split_by_section(c, name, subspath, path):
+    """Split assignments by section of submitting student."""
+    if not os.path.isdir(subspath):
+        raise LookupError("Submission path %s does not exist" % subspath)
+
+    name = slugify(name)
+    splitbase = os.path.join(path, name)
+    subbase = os.path.join(subspath, name)
+
+    if os.path.exists(splitbase):
+        raise Exception("Split target directory %s already exists."
+                        % splitbase)
+    splitbase = os.path.abspath(splitbase)
+
+    if not os.path.exists(subbase):
+        raise Exception("Submission directory %s not found." % subbase)
+    subbase = os.path.abspath(subbase)
+
+    sections = canvas.SectionList(c)
+    students = canvas.StudentList(searchdir="students")
+
+    # Create folders for each section
+    mkdir(path)
+    mkdir(splitbase)
+    for sec in sections.sections():
+        d = os.path.join(splitbase, sec)
+        mkdir(d)
+
+    # Symlink folders from submission directory to destination
+    for uid, namelist in sections.sectmap().items():
+        dirname = student_dirname(students[uid])
+        subpath = os.path.join(subbase, dirname)
+        for name in namelist:
+            splitpath = os.path.join(splitbase, os.path.join(name, dirname))
+            if not os.path.isdir(subpath):
+                continue
+            os.symlink(subpath, splitpath)
+
+
 def main_args_parser():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawTextHelpFormatter,
@@ -269,6 +309,14 @@ Grade a submission:
         [-f FILEPATH]   Upload the contents of a file as a comment.
         [-1]            Only upload feedback for 1 student id (instead of all).
         [FILEPATH]...   Optional files to upload alongside.
+
+Split submissions by sections:
+    sectsplit ASSIGNMENT_NAME SUBDIR SPLITDIR
+
+    Where
+        ASSIGNMENT_NAME Name of assignment that should be split.
+        SUBDIR          Name of directory holding submissions to split.
+        SPLITDIR        Name of directory that splits should be symlinked into.
 
 Work with groups:
     group add group GROUP_CATEGORY GROUP_NAME
@@ -472,6 +520,13 @@ def find_user(user_name):
 def groupsplit(args):
     split_according_to_groups(canvas.Course(), args[0], args[1])
 
+
+def sectsplit(name, subs=None, splits=None):
+    """Split submissions according to sections."""
+    subs = subs if subs else "subs"
+    splits = splits if splits else "splits"
+    split_by_section(canvas.Course(), name, subs, splits)
+
 def _check_grade(grade):
     goodgrades = ["pass", "fail", "incomplete"]
     if not grade in goodgrades:
@@ -558,6 +613,8 @@ def main():
         user(remargs)
     elif action == "groupsplit":
         groupsplit(remargs)
+    elif action == "sectsplit":
+        sectsplit(*remargs)
     else:
         print("Unknown action {}.".format(action))
         parser.print_usage()


### PR DESCRIPTION
This PR adds an additional command for splitting student submissions based on which section a student belongs to. Fetched submissions are symlinked to a directory named after the section that the submitting student belongs to. If a student belongs to more than one section, more than one symlink will be created accordingly.

I'm happy to make additional changes as needed.