### PR TITLE
Add parameter to grade specific person.

### DIFF
--- a/staffeli/cli.py
+++ b/staffeli/cli.py
@@ -261,13 +261,14 @@ Update a working area:
     fetch   Fetch something that might have changed
 
 Grade a submission:
-    grade GRADE [-m COMMENT] [-1] [FILEPATH]...
+    grade GRADE [-m COMMENT] [-1 | --kuid KUID] [FILEPATH]...
 
     Where
         GRADE           pass, fail, incomplete, or an int.
         [-m COMMENT]    An optional comment to write.
         [-f FILEPATH]   Upload the contents of a file as a comment.
         [-1]            Only upload feedback for 1 student id (instead of all).
+        [--kuid KUID]   Upload feedback for a specific student.
         [FILEPATH]...   Optional files to upload alongside.
 
 Work with groups:

--- a/staffeli/cli.py
+++ b/staffeli/cli.py
@@ -499,7 +499,10 @@ def grade_args_parser():
 
     parser.add_argument('grade', metavar='GRADE')
     parser.add_argument('attachments', nargs='*')
-    parser.add_argument('-1', action='store_true', dest='one', default=False)
+
+    people = parser.add_mutually_exclusive_group()
+    people.add_argument('-1', action='store_true', dest='one', default=False)
+    people.add_argument('--kuid', dest='kuid')
 
     comments = parser.add_mutually_exclusive_group(required=True)
     comments.add_argument('-m', metavar='COMMENT', dest='comment')
@@ -532,6 +535,21 @@ def grade(args):
     student_ids = submission.student_ids
     if args.one:
         student_ids = student_ids[:1]
+    elif args.kuid is not None:
+        users_found = _find_user(args.kuid)
+        if len(users_found) == 1:
+            user_id = users_found[0]['id']
+            student_ids = [user_id]
+        elif len(users_found) > 1:
+            print("Kuid is too ambiguous! Found multiple users with the kuid {}:.".format(args.kuid))
+            for user in users_found:
+                print('- id: {}, login_id: {}, kuid: {}, name: {}'.format(
+                    user['id'], user['login_id'], user['kuid'], user['name']))
+            sys.exit(1)
+        else:
+            print("Found no users with the kuid {}!".format(args.kuid))
+            sys.exit(1)
+
     for sub in assignment.submissions():
         if sub['user_id'] in student_ids:
             current_grade = sub['grade']


### PR DESCRIPTION
This pull request adds functionality to grade a specific person using `staffeli grade --kuid <kuid>`.

For example, running the following command
```Bash
staffeli grade --kuid dvf159 -f feedback.txt 4
```
will give me a grade, even if another group-member submitted the assignment and group-submissions aren't enabled.

I have graded 22 people using this with no hiccups, but I don't know if it breaks any existing functionality.

Please let me know if any changes are needed.